### PR TITLE
[CI] Update ownership for workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# CI Infrastructure team
+.github/workflows/ @toptal/ci-infrastructure-eng


### PR DESCRIPTION
[CI-1109](https://toptal-core.atlassian.net/browse/CI-1109)


### Review

 Check list of the ownership for `.github/workflows/` [here](https://docs.google.com/spreadsheets/d/1JQ54Fbzr1_6Y9Vgbq5bqhxubdhm7m8jOL8SFPbEWkOA/edit#gid=838491615)
 
 Checked the team and its rights for r/w and it is in place.
https://github.com/orgs/toptal/teams/ci-infrastructure-eng